### PR TITLE
add support for multiple tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ Setting this up requires doing some initial Firebase setup, then doing some init
 3. Deploy your project by running `firebase deploy`.
 4. When it finishes deploying, it will log the URL for each Function. Note the "Function URL" for `slashStart` (e.g., https://us-central1-PROJECTID.cloudfunctions.net/slashStart)
 
+On a single installation, if you have multiple Mattermost teams and want to use the slash command on each, then you have to register several tokens (one for each slash command created).
+For that you can define token to contain several command id by separating them using a comma `firebase functions:config:set mattermost.token="token1,token2,token3"`
+
+The resulting Firebase environment config should look like:
+```
+ᐅ firebase functions:config:get
+{
+  "mattermost": {
+    "token": "token1,token2,token3"
+  },
+  "functions": {
+    "baseurl": "https://us-central1-myprojectid.cloudfunctions.net"
+  }
+}
+```
+
 ### Finish Mattermost Setup
 1. Edit your Mattermost Slash command and update the Request URL to be the URL of your Firebase Functions `slashStart` function
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -27,6 +27,7 @@ exports.slashStart = functions.https.onRequest((req, res) => {
   if (!utils.isValidSlashRequest(req)) {
     return res.status(401).send('Invalid request or missing token');
   }
+  const token = req.body.token;
   const textPieces = req.body.text ? req.body.text.split("|") : [];
   if (textPieces.length <= 1) {
     console.info('Did not find valid text, returning');
@@ -66,10 +67,10 @@ exports.slashStart = functions.https.onRequest((req, res) => {
     const optionKeys = optionData ? Object.keys(optionData): [];
     for (const optionKey of optionKeys) {
       const optionValue = optionData[optionKey];
-      attachmentActions.push(utils.buildAction('🖐️', optionValue.label, 'yellow', '/slashVote', newPollRef.key, optionKey));
+      attachmentActions.push(utils.buildAction('🖐️', optionValue.label, 'yellow', '/slashVote', newPollRef.key, token, optionKey));
     };
-    attachmentActions.push(utils.buildAction('🔍', 'Get Vote Count', null, '/slashCount', newPollRef.key, null));
-    attachmentActions.push(utils.buildAction('🏁', 'Close Poll', null, '/slashEnd', newPollRef.key, null));
+    attachmentActions.push(utils.buildAction('🔍', 'Get Vote Count', null, '/slashCount', newPollRef.key, token, null));
+    attachmentActions.push(utils.buildAction('🏁', 'Close Poll', null, '/slashEnd', newPollRef.key, token, null));
 
     console.info(`Successfully created poll ${newPollRef.key} and built actions`, attachmentActions);
     // https://docs.mattermost.com/developer/interactive-message-buttons.html

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -8,7 +8,8 @@ function deepCopy(object) {
 }
 
 function isValidToken(token){
-  return token && token === MM_INTEGRATION_TOKEN;
+  var tokens = MM_INTEGRATION_TOKEN ? MM_INTEGRATION_TOKEN.split(',') : [];
+  return token && tokens.indexOf(token) !== -1;
 }
 
 function isValidSlashRequest(req){
@@ -29,7 +30,7 @@ function isValidActionRequest(req){
   }
 }
 
-function buildAction(icon, name, color, urlStub, pollKey, optionKey) {
+function buildAction(icon, name, color, urlStub, pollKey, token, optionKey) {
   return {
     name: `${icon} ${name}`,
     color,
@@ -37,7 +38,7 @@ function buildAction(icon, name, color, urlStub, pollKey, optionKey) {
       url: BASE_URL + urlStub,
       context: {
         pollKey: pollKey,
-        token: MM_INTEGRATION_TOKEN,
+        token: token,
         optionKey
       }
     }


### PR DESCRIPTION
In case the mattermost installation contains multiple teams, and that several slash commands are deployed separately in each team, then the need for multiple slash command id (tokens) is required.

This PR provide the minimum to handle this case.

_PS: not being a JS dev there are probaly more elegant ways of achieving this._